### PR TITLE
Update 04_numpy.ipynb

### DIFF
--- a/04_numpy.ipynb
+++ b/04_numpy.ipynb
@@ -72,7 +72,7 @@
     "\n",
     "# Making random arrays\n",
     "rand_array = np.random.random([5,2]) # Drawn from uniform random distribution on [0,1)\n",
-    "rand_array2 = np.random.normal([3,3,3]) #Drawn from a standard normal distribution (mean 0, stdev 1)"
+    "rand_array2 = np.random.normal(size=[3,3,3]) #Drawn from a standard normal distribution (mean 0, stdev 1)"
    ]
   },
   {


### PR DESCRIPTION
Fix call to np.random.normal to match its comment.

It looks like this line should produce a cube matrix (3x3x3) of values taken from a normal distribution with a mean of 0 and standard deviation of 1.

However what seems to be happening is that the array argument that is provided is being destructured into individual parameters. Put another way, while we expect that this input array will be used to define the shape of our output matrix, instead the array is being split up, with each element being used as the value of a different parameter.

eg. Instead the expected call of np.random.normal(size=[3,3,3]) the function call that happens is actually np.random.normal(loc=3, scale=3, size=3);

This change disambiguates between the above two function calls by explicitly indicating the array we've provided should be matched to the size parameter.